### PR TITLE
Fix heading typography

### DIFF
--- a/_docs/mk-prompts.md
+++ b/_docs/mk-prompts.md
@@ -193,3 +193,11 @@ The markdown should now display with proper heading sizes, formatting, and synta
 ```
 still not working---please commit and push what we have so far and I will get OpenAI's Codex to work on this problem instead.
 ```
+## User Request 18
+```
+can you investigate the markdown rendering issue? h2 h3 etc are not bold or larger. Where are we styling the markdown?  I want to go with 900 inter for headings at appropriate sizes, and then 500 for body text.
+```
+
+## Claude Response 18
+Investigation shows that markdown is styled via the `@tailwindcss/typography` plugin and custom rules in `app/globals.css`. Headings inherited the `font-medium` weight from the `body` element, so they were not bold. Added typography overrides in `globals.css` to apply `font-black` (900 weight) to all headings and `font-medium` (500 weight) to regular text.
+

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -55,3 +55,32 @@ body {
   border-radius: 0;
   font-size: inherit;
 }
+
+/* Typography overrides */
+.prose h1 {
+  @apply font-black text-5xl;
+}
+
+.prose h2 {
+  @apply font-black text-4xl;
+}
+
+.prose h3 {
+  @apply font-black text-3xl;
+}
+
+.prose h4 {
+  @apply font-black text-2xl;
+}
+
+.prose h5 {
+  @apply font-black text-xl;
+}
+
+.prose h6 {
+  @apply font-black;
+}
+
+.prose p {
+  @apply font-medium;
+}


### PR DESCRIPTION
## Summary
- document latest conversation in `_docs/mk-prompts.md`
- ensure markdown headings use Inter 900 and body text uses Inter 500

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684083e1e05c8325a56aed6d172219a4